### PR TITLE
added a deconstructor

### DIFF
--- a/WS2812Serial.h
+++ b/WS2812Serial.h
@@ -40,6 +40,9 @@ public:
 		numled(num), pin(pin), config(cfg),
 		frameBuffer((uint8_t *)fb), drawBuffer((uint8_t *)db) {
 	}
+	~WS2812Serial() {
+		delete dma;
+	}
 	bool begin();
 	void setPixel(uint32_t num, int color) {
 		if (num >= numled) return;


### PR DESCRIPTION
added a deconstructor to manage the dma memory. Needed for dynamic creation and destruction of WS2812Serial objects. 
Note: that you will have to manage the display and drawing memory externally.

I am currently working on a project that involves dynamically creating led strips at run time. I found that if i deleted a WS2812Serial object and redeclared a new one with the same attributes, the light data output would fail. Adding memory management for the DMAChannel fixes this issue.